### PR TITLE
Declare properties to fix PHP 8.2 dynamic property deprecations

### DIFF
--- a/classes/class-admin-contact-post-type.php
+++ b/classes/class-admin-contact-post-type.php
@@ -7,6 +7,13 @@ class Orbis_Contacts_AdminContactPostType {
 	const POST_TYPE = 'orbis_person';
 
 	/**
+	 * Plugin.
+	 *
+	 * @var Orbis_Plugin
+	 */
+	private $plugin;
+
+	/**
 	 * Construct.
 	 */
 	public function __construct( $plugin ) {

--- a/classes/orbis-contacts-exporter.php
+++ b/classes/orbis-contacts-exporter.php
@@ -11,6 +11,13 @@
  */
 class Orbis_ContactsExporter {
 	/**
+	 * Plugin.
+	 *
+	 * @var Orbis_Plugin
+	 */
+	private $plugin;
+
+	/**
 	 * Constructs and initialize a Orbis CSV.
 	 */
 	public function __construct( $plugin ) {

--- a/classes/orbis-core-admin.php
+++ b/classes/orbis-core-admin.php
@@ -17,6 +17,27 @@ class Orbis_Core_Admin {
 	 */
 	private $plugin;
 
+	/**
+	 * Settings
+	 *
+	 * @var Orbis_Core_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Contact post type
+	 *
+	 * @var Orbis_Contacts_AdminContactPostType
+	 */
+	private $contact_post_type;
+
+	/**
+	 * Contacts importer
+	 *
+	 * @var Orbis_Core_ContactsImporter
+	 */
+	private $contacts_importer;
+
 	//////////////////////////////////////////////////
 
 	/**

--- a/classes/orbis-core-email.php
+++ b/classes/orbis-core-email.php
@@ -1,6 +1,13 @@
 <?php
 
 class Orbis_Core_Email {
+	/**
+	 * Plugin.
+	 *
+	 * @var Orbis_Plugin
+	 */
+	private $plugin;
+
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
 

--- a/classes/orbis-core-plugin.php
+++ b/classes/orbis-core-plugin.php
@@ -1,6 +1,34 @@
 <?php
 
 class Orbis_Core_Plugin extends Orbis_Plugin {
+	/**
+	 * API.
+	 *
+	 * @var Orbis_API
+	 */
+	public $api;
+
+	/**
+	 * Email.
+	 *
+	 * @var Orbis_Core_Email
+	 */
+	public $email;
+
+	/**
+	 * Orbis vCard.
+	 *
+	 * @var Orbis_VCard
+	 */
+	public $vcard;
+
+	/**
+	 * Contacts exporter.
+	 *
+	 * @var Orbis_ContactsExporter
+	 */
+	public $contacts_exporter;
+
 	public function __construct( $file ) {
 		parent::__construct( $file );
 

--- a/classes/orbis-plugin-manager.php
+++ b/classes/orbis-plugin-manager.php
@@ -220,6 +220,20 @@ class Orbis_Empty_Upgrader_Skin extends WP_Upgrader_Skin {
 	public $error;
 
 	/**
+	 * Type
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * API
+	 *
+	 * @var mixed
+	 */
+	public $api;
+
+	/**
 	 * Constructs and initialize an Orbis empty upgrader skin
 	 *
 	 * @param mixed $args

--- a/classes/orbis-plugin.php
+++ b/classes/orbis-plugin.php
@@ -16,6 +16,13 @@ class Orbis_Plugin {
 
 	public $dir_path;
 
+	/**
+	 * Name of this plugin.
+	 *
+	 * @var string
+	 */
+	public $name;
+
 	public $db_version;
 
 	//////////////////////////////////////////////////

--- a/classes/orbis-vcard.php
+++ b/classes/orbis-vcard.php
@@ -11,6 +11,13 @@
  */
 class Orbis_VCard {
 	/**
+	 * Plugin.
+	 *
+	 * @var Orbis_Plugin
+	 */
+	private $plugin;
+
+	/**
 	 * Constructs and initialize a Orbis vCard.
 	 */
 	public function __construct( $plugin ) {


### PR DESCRIPTION
Fixes #125

## Problem

On PHP 8.2+ the plugin created dynamic properties, so every request on the production site logged `Creation of dynamic property ... is deprecated` notices.

## Solution

Declare the properties explicitly on the classes involved. `#[\AllowDynamicProperties]` is deliberately **not** used. Visibility and docblock style follow the surrounding (older, untyped) code — no mass refactor, no behaviour change.

| Class | File | Properties declared |
| --- | --- | --- |
| `Orbis_Plugin` | `classes/orbis-plugin.php` | `$name` |
| `Orbis_Core_Plugin` | `classes/orbis-core-plugin.php` | `$api`, `$email`, `$vcard`, `$contacts_exporter` |
| `Orbis_Core_Email` | `classes/orbis-core-email.php` | `$plugin` |
| `Orbis_VCard` | `classes/orbis-vcard.php` | `$plugin` |
| `Orbis_ContactsExporter` | `classes/orbis-contacts-exporter.php` | `$plugin` |
| `Orbis_Contacts_AdminContactPostType` | `classes/class-admin-contact-post-type.php` | `$plugin` |
| `Orbis_Core_Admin` | `classes/orbis-core-admin.php` | `$settings`, `$contact_post_type`, `$contacts_importer` |
| `Orbis_Empty_Upgrader_Skin` | `classes/orbis-plugin-manager.php` | `$type`, `$api` |

Notes:

- All `Orbis_*_Plugin::$name` entries in the log (deals, websites, monitoring, Twinfield, the namespaced `Notifications\Plugin`, …) originate from `Orbis_Plugin::set_name()` and are fixed by the single base-class declaration.
- `$db_version` was already declared.
- `Orbis_Empty_Upgrader_Skin` extends `WP_Upgrader_Skin`, which does not declare `$type` or `$api`, so both are declared locally. These were not in the log excerpt but are hit by the plugin install/activate AJAX handlers.

## Verification

- A token-based scan of the whole repository (excluding `vendor`, `build`, `node_modules`) for `$this->prop = …` assignments without a matching declaration now reports **zero** remaining offenders. Before this change it reported exactly the set above.
- `php -l` passes on all eight changed files.
- `composer phpcs` on the changed files reports the same totals as before the change (20 errors / 17 warnings), i.e. all pre-existing and unrelated — no new violations introduced.

## Out of scope

The issue also mentions `FILTER_SANITIZE_STRING`, deprecated since PHP 8.1. That one needs actual sanitisation behaviour changes across a number of `filter_input()` calls, so it is kept out of this PR and should be handled separately.