### PR TITLE
Replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/admin/contacts-import.php
+++ b/admin/contacts-import.php
@@ -2,7 +2,7 @@
 
 check_admin_referer( 'orbis_contacts_import', 'orbis_contacts_import_nonce' );
 
-$attachment_id = filter_input( INPUT_GET, 'attachment_id', FILTER_SANITIZE_STRING );
+$attachment_id = filter_input( INPUT_GET, 'attachment_id', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
 $offset        = filter_input( INPUT_GET, 'offset', FILTER_VALIDATE_INT );
 $count         = filter_input( INPUT_GET, 'count', FILTER_VALIDATE_INT );
 

--- a/classes/class-admin-contact-post-type.php
+++ b/classes/class-admin-contact-post-type.php
@@ -63,7 +63,9 @@ class Orbis_Contacts_AdminContactPostType {
 		}
 
 		// Verify nonce
-		$nonce = filter_input( INPUT_POST, 'orbis_person_details_meta_box_nonce', FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_POST, 'orbis_person_details_meta_box_nonce', FILTER_UNSAFE_RAW );
+		$nonce = ( null === $nonce ) ? '' : sanitize_text_field( wp_unslash( $nonce ) );
+
 		if ( ! wp_verify_nonce( $nonce, 'orbis_save_person_details' ) ) {
 			return;
 		}
@@ -75,26 +77,30 @@ class Orbis_Contacts_AdminContactPostType {
 
 		// OK
 		$definition = [
-			'_orbis_title'             => FILTER_SANITIZE_STRING,
-			'_orbis_organization'      => FILTER_SANITIZE_STRING,
-			'_orbis_department'        => FILTER_SANITIZE_STRING,
+			'_orbis_title'             => FILTER_UNSAFE_RAW,
+			'_orbis_organization'      => FILTER_UNSAFE_RAW,
+			'_orbis_department'        => FILTER_UNSAFE_RAW,
 			'_orbis_email'             => FILTER_VALIDATE_EMAIL,
-			'_orbis_phone_number'      => FILTER_SANITIZE_STRING,
-			'_orbis_mobile_number'     => FILTER_SANITIZE_STRING,
-			'_orbis_address'           => FILTER_SANITIZE_STRING,
-			'_orbis_postcode'          => FILTER_SANITIZE_STRING,
-			'_orbis_city'              => FILTER_SANITIZE_STRING,
-			'_orbis_country'           => FILTER_SANITIZE_STRING,
-			'_orbis_birth_date_string' => FILTER_SANITIZE_STRING,
-			'_orbis_iban'              => FILTER_SANITIZE_STRING,
-			'_orbis_twitter'           => FILTER_SANITIZE_STRING,
-			'_orbis_facebook'          => FILTER_SANITIZE_STRING,
-			'_orbis_linkedin'          => FILTER_SANITIZE_STRING,
+			'_orbis_phone_number'      => FILTER_UNSAFE_RAW,
+			'_orbis_mobile_number'     => FILTER_UNSAFE_RAW,
+			'_orbis_address'           => FILTER_UNSAFE_RAW,
+			'_orbis_postcode'          => FILTER_UNSAFE_RAW,
+			'_orbis_city'              => FILTER_UNSAFE_RAW,
+			'_orbis_country'           => FILTER_UNSAFE_RAW,
+			'_orbis_birth_date_string' => FILTER_UNSAFE_RAW,
+			'_orbis_iban'              => FILTER_UNSAFE_RAW,
+			'_orbis_twitter'           => FILTER_UNSAFE_RAW,
+			'_orbis_facebook'          => FILTER_UNSAFE_RAW,
+			'_orbis_linkedin'          => FILTER_UNSAFE_RAW,
 		];
 
 		$data = filter_input_array( INPUT_POST, $definition );
 
 		foreach ( $data as $key => $value ) {
+			if ( is_string( $value ) ) {
+				$value = sanitize_text_field( wp_unslash( $value ) );
+			}
+
 			if ( empty( $value ) ) {
 				delete_post_meta( $post_id, $key );
 			} else {

--- a/classes/orbis-contacts-importer.php
+++ b/classes/orbis-contacts-importer.php
@@ -153,9 +153,10 @@ class Orbis_Core_ContactsImporter {
 
 		check_admin_referer( 'orbis_contacts_import', 'orbis_contacts_import_nonce' );
 
-		$attachment_id = filter_input( INPUT_POST, 'attachment_id', FILTER_SANITIZE_STRING );
+		$attachment_id = filter_input( INPUT_POST, 'attachment_id', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
 
-		$map = filter_input( INPUT_POST, 'map', FILTER_SANITIZE_STRING, FILTER_FORCE_ARRAY );
+		$map = filter_input( INPUT_POST, 'map', FILTER_UNSAFE_RAW, FILTER_FORCE_ARRAY );
+		$map = ( null === $map ) ? [] : array_map( 'sanitize_text_field', wp_unslash( $map ) );
 
 		update_post_meta( $attachment_id, '_orbis_contacts_import_map', $map );
 
@@ -254,7 +255,7 @@ class Orbis_Core_ContactsImporter {
 
 		$url = $this->get_import_contacts_url(
 			[
-				'attachment_id' => filter_input( INPUT_POST, 'attachment_id', FILTER_SANITIZE_STRING ),
+				'attachment_id' => filter_input( INPUT_POST, 'attachment_id', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE ),
 			]
 		);
 
@@ -362,8 +363,10 @@ class Orbis_Core_ContactsImporter {
 	}
 
 	public function page_contacts_import() {
-		$attachment_id = filter_input( INPUT_GET, 'attachment_id', FILTER_SANITIZE_STRING );
-		$step          = filter_input( INPUT_GET, 'step', FILTER_SANITIZE_STRING );
+		$attachment_id = filter_input( INPUT_GET, 'attachment_id', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
+
+		$step = filter_input( INPUT_GET, 'step', FILTER_UNSAFE_RAW );
+		$step = ( null === $step ) ? '' : sanitize_text_field( wp_unslash( $step ) );
 
 		include plugin_dir_path( $this->plugin->file ) . '/admin/page-contacts-import.php';
 	}

--- a/classes/orbis-core-admin.php
+++ b/classes/orbis-core-admin.php
@@ -341,7 +341,8 @@ class Orbis_Core_Admin {
 	 * Called through the WordPress AJAX hook. Installs a plugin that matches the slug passed through the $_POST variable.
 	 */
 	public function orbis_install_plugin() {
-		$plugin_slug = filter_input( INPUT_POST, 'plugin_slug', FILTER_SANITIZE_STRING );
+		$plugin_slug = filter_input( INPUT_POST, 'plugin_slug', FILTER_UNSAFE_RAW );
+		$plugin_slug = ( null === $plugin_slug ) ? '' : sanitize_text_field( wp_unslash( $plugin_slug ) );
 
 		if ( ! $plugin_slug ) {
 			die(
@@ -386,7 +387,8 @@ class Orbis_Core_Admin {
 	 * Called through the WordPress AJAX hook. Activates a plugin that matches the slug passed through the $_POST variable.
 	 */
 	public function orbis_activate_plugin() {
-		$plugin_slug = filter_input( INPUT_POST, 'plugin_slug', FILTER_SANITIZE_STRING );
+		$plugin_slug = filter_input( INPUT_POST, 'plugin_slug', FILTER_UNSAFE_RAW );
+		$plugin_slug = ( null === $plugin_slug ) ? '' : sanitize_text_field( wp_unslash( $plugin_slug ) );
 
 		if ( ! $plugin_slug ) {
 			die(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,7 +1,8 @@
 <?php
 
 function orbis_filter_time_input( $type, $variable_name ) {
-	$value = filter_input( $type, $variable_name, FILTER_SANITIZE_STRING );
+	$value = filter_input( $type, $variable_name, FILTER_UNSAFE_RAW );
+	$value = ( null === $value ) ? '' : sanitize_text_field( wp_unslash( $value ) );
 
 	return orbis_parse_time( $value );
 }

--- a/includes/persons.php
+++ b/includes/persons.php
@@ -3,7 +3,8 @@
 function orbis_persons_suggest_person_id() {
 	global $wpdb;
 
-	$term = filter_input( INPUT_GET, 'term', FILTER_SANITIZE_STRING );
+	$term = filter_input( INPUT_GET, 'term', FILTER_UNSAFE_RAW );
+	$term = ( null === $term ) ? '' : sanitize_text_field( wp_unslash( $term ) );
 
 	$query = "
 		SELECT


### PR DESCRIPTION
`FILTER_SANITIZE_STRING` is deprecated since PHP 8.1 and scheduled for removal. This replaces all 25 occurrences, choosing the replacement per call site based on the intent of the value.

## Changes

**Numeric IDs → `FILTER_VALIDATE_INT` with `FILTER_NULL_ON_FAILURE`**

Invalid or missing input yields `null` instead of `false`, so existing `empty()` checks, `esc_attr()` and `selected()` calls keep behaving as before.

- `admin/contacts-import.php` – `attachment_id`
- `classes/orbis-contacts-importer.php` – `attachment_id` (3×)

**Free text and nonces → `FILTER_UNSAFE_RAW` + explicit sanitization**

Each value is passed through `sanitize_text_field( wp_unslash( … ) )`, with a `null` guard for absent fields so downstream code always receives a string.

- `classes/class-admin-contact-post-type.php` – nonce and the 14 person detail meta fields (sanitized after `filter_input_array()`; the `_orbis_email` field keeps `FILTER_VALIDATE_EMAIL`)
- `classes/orbis-contacts-importer.php` – `map` (array, sanitized per element) and `step`
- `classes/orbis-core-admin.php` – `plugin_slug` (2×)
- `includes/functions.php` – `orbis_filter_time_input()`
- `includes/persons.php` – person suggest `term`

`FILTER_DEFAULT` was deliberately not used, since it would silently drop sanitization.

## Verification

- `php -l` passes on all six changed files.
- No occurrences of `FILTER_SANITIZE_STRING` remain in the repository.
- `phpcs` could not be run because dev dependencies are not installed in this environment; no new tooling was added.

Fixes #127