### PR TITLE
Add PHP Deployer

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,6 +32,8 @@ psalm.xml
 
 /vendor/bin/
 
+/deploy.php
+
 /build/
 /deploy/
 /node_modules/

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
 	"require-dev": {
 		"pronamic/wp-coding-standards": "^2.1",
 		"wp-cli/dist-archive-command": "*",
-		"wp-cli/wp-cli-bundle": "*"
+		"wp-cli/wp-cli-bundle": "*",
+		"deployer/deployer": "^7.5"
 	},
 	"scripts": {
 		"build": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b63f5c95e3fab5211c8cfadc1018f67",
+    "content-hash": "9a44d89a9bdc4dcbfdc98f6ad5a35361",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -2007,6 +2007,60 @@
                 }
             ],
             "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "deployer/deployer",
+            "version": "v7.5.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deployphp/deployer.git",
+                "reference": "efc71dac9ccc86b3f9946e75d50cb106b775aae2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/efc71dac9ccc86b3f9946e75d50cb106b775aae2",
+                "reference": "efc71dac9ccc86b3f9946e75d50cb106b775aae2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.0|^7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pestphp/pest": "^3.3",
+                "phpstan/phpstan": "^1.4",
+                "phpunit/php-code-coverage": "^11.0",
+                "phpunit/phpunit": "^11.4"
+            },
+            "bin": [
+                "bin/dep"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Medvedev",
+                    "email": "anton@medv.io"
+                }
+            ],
+            "description": "Deployment Tool",
+            "homepage": "https://deployer.org",
+            "support": {
+                "docs": "https://deployer.org/docs",
+                "issues": "https://github.com/deployphp/deployer/issues",
+                "source": "https://github.com/deployphp/deployer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/antonmedv",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-19T16:45:27+00:00"
         },
         {
             "name": "eftec/bladeone",

--- a/deploy.php
+++ b/deploy.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Deploy
+ *
+ * @package Pronamic\Orbis
+ */
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+require 'recipe/common.php';
+
+set( 'plugin_slug', 'orbis' );
+
+set( 'build_path', './build/' );
+
+host( 'orbis.pronamic.nl' )
+	->set( 'hostname', 'esm7.siteground.biz' )
+	->set( 'remote_user', 'u155-jlog1cramrrx' )
+	->set( 'port', 18765 )
+	->set( 'deploy_path', '~/projects/wp-orbis' )
+	->set( 'plugins_dir', '~/www/orbis.pronamic.nl/public_html/wp-content/plugins' );
+
+/**
+ * Build.
+ *
+ * @link https://github.com/woocommerce/woocommerce/blob/48fdb94bf311c977d15cbaa3d8dab66bac01feb7/plugins/woocommerce/.distignore
+ * @link https://github.com/woocommerce/woocommerce/blob/48fdb94bf311c977d15cbaa3d8dab66bac01feb7/plugins/woocommerce/bin/build-zip.sh
+ */
+task(
+	'build',
+	function () {
+		runLocally( 'composer run-script build' );
+	}
+);
+
+task(
+	'deploy:update_code',
+	function () {
+		upload( '{{build_path}}/orbis/', '{{release_path}}' );
+	}
+);
+
+task(
+	'deploy:symlink_plugin',
+	function () {
+		run( 'ln -sfn {{deploy_path}}/current {{plugins_dir}}/{{plugin_slug}}' );
+	}
+);
+
+after( 'deploy:symlink', 'deploy:symlink_plugin' );
+
+task(
+	'deploy',
+	[
+		'build',
+		'deploy:prepare',
+		'deploy:publish',
+	]
+);


### PR DESCRIPTION
Adds [PHP Deployer](https://deployer.org/) for deploying the Orbis plugin to `orbis.pronamic.nl`.

- `composer require --dev deployer/deployer` (`^7.5`, older versions crash on PHP 8.5)
- New `deploy.php` recipe:
  - Builds via the existing `composer run-script build` (unchanged, builds to `./build/orbis/`)
  - Uploads `./build/orbis/` to `~/projects/wp-orbis` on `esm7.siteground.biz` (port 18765)
  - Symlinks the current release into the plugins directory
- `.distignore`: added `/deploy.php`

Validated with `vendor/bin/dep list`.