### PR TITLE
fix: add CSRF protection in contacts-import.php

### DIFF
--- a/admin/contacts-import.php
+++ b/admin/contacts-import.php
@@ -2,6 +2,10 @@
 
 check_admin_referer( 'orbis_contacts_import', 'orbis_contacts_import_nonce' );
 
+if ( ! current_user_can( 'import' ) ) {
+	wp_die( esc_html__( 'Sorry, you are not allowed to import contacts.', 'orbis' ) );
+}
+
 $attachment_id = filter_input( INPUT_GET, 'attachment_id', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
 $offset        = filter_input( INPUT_GET, 'offset', FILTER_VALIDATE_INT );
 $count         = filter_input( INPUT_GET, 'count', FILTER_VALIDATE_INT );


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `admin/contacts-import.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `admin/contacts-import.php:1` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-352 |

**Description**: The admin import endpoints lack proper WordPress capability checks. While check_admin_referer() is called for CSRF protection, there is no current_user_can() check to verify the user has administrative privileges before executing import operations. This allows any authenticated WordPress user (subscriber, contributor, author) to access the import functionality by directly navigating to the endpoint URL.

## Evidence

**Exploitation scenario**: An attacker with a valid WordPress subscriber or contributor account can directly access the admin import endpoint by navigating to /wp-admin/admin.php?page=orbis-contacts-import&step=import&attachmen.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `admin/contacts-import.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
