### PR TITLE
Remove deprecated IE conditional script data

### DIFF
--- a/includes/flot.php
+++ b/includes/flot.php
@@ -26,19 +26,6 @@ function orbis_flot( $element_id, $data, $options ) {
  */
 function orbis_flot_enqueue_scripts() {
 	global $orbis_plugin;
-	global $wp_scripts;
-
-	$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-
-	// Register scripts
-	wp_register_script(
-		'excanvas',
-		$orbis_plugin->plugin_url( 'includes/js/flot/excanvas' . $suffix . '.js' )
-	);
-
-	// @see http://wordpress.stackexchange.com/a/20877
-	// @see https://github.com/flot/flot/blob/master/examples/basic.html
-	$wp_scripts->add_data( 'excanvas', 'conditional', 'lte IE 8' );
 
 	wp_register_script(
 		'jquery-flot',


### PR DESCRIPTION
## Summary

- Remove the legacy `excanvas` script registration for IE 8
- Remove the deprecated IE conditional script data that triggers the WordPress 6.9 notice

Fixes #135.

## Testing

- `php -l includes/flot.php`
- `composer phpcs -- --standard=phpcs.xml.dist includes/flot.php` *(fails on pre-existing escaping/resource-parameter warnings in `includes/flot.php`, unrelated to this removal)*